### PR TITLE
Doppel struct

### DIFF
--- a/cache_entry.go
+++ b/cache_entry.go
@@ -1,0 +1,65 @@
+package doppel
+
+import "html/template"
+
+type cacheEntry struct {
+	ready chan struct{}
+	tmpl  *template.Template
+	err   error
+}
+
+func (ce *cacheEntry) parse(req *request, s *TemplateSchematic) {
+	defer close(ce.ready)
+
+	var err error
+	select {
+	case <-req.ctx.Done():
+		ce.deliverErr(req.ctx.Err(), req)
+	default:
+	}
+
+	var tmpl *template.Template
+	if s.baseTmplName == "" {
+		tmpl, err = template.ParseFiles(s.filepaths...)
+	} else {
+		base, err := Get(s.baseTmplName)
+		if err != nil {
+			ce.err = err
+			return
+		}
+		tmpl, err = base.ParseFiles(s.filepaths...)
+	}
+	if err != nil {
+		ce.err = err
+		return
+	}
+
+	ce.tmpl = tmpl
+	return
+}
+
+func (ce *cacheEntry) deliver(req *request) {
+	select {
+	case <-req.ctx.Done():
+		ce.deliverErr(req.ctx.Err(), req)
+	case <-ce.ready:
+	}
+
+	if ce.err != nil {
+		req.resultStream <- &result{err: ce.err}
+		return
+	}
+
+	clone, err := ce.tmpl.Clone()
+	if err != nil {
+		req.resultStream <- &result{err: ce.err}
+		return
+	}
+	req.resultStream <- &result{tmpl: clone}
+	return
+}
+
+func (ce *cacheEntry) deliverErr(err error, req *request) {
+	ce.err = err
+	req.resultStream <- &result{err: err}
+}

--- a/default.go
+++ b/default.go
@@ -1,0 +1,40 @@
+package doppel
+
+import (
+	"html/template"
+
+	"github.com/pkg/errors"
+)
+
+// defaultCache supports package-level template composition and
+// caching.
+var defaultCache *Doppel
+
+// Initialize starts the default, package-level cache and sets the
+// requestStream by which requests are sent to the cache. Attempting
+// to perform operations like Get on the default cache before
+// it is initialized will return an error.
+//
+// The user is responsible for closing the default cache via the
+// supplied done channel when finished.
+func Initialize(done chan struct{}, schematic CacheSchematic, opts ...Option) {
+	cancelOpt := func(d *Doppel) *Doppel {
+		d.done = done
+		return d
+	}
+
+	d := New(schematic, append(opts, cancelOpt)...)
+	defaultCache = d
+}
+
+// Get returns a copy of the name template if it exists in the cache,
+// or an error if it does not.
+//
+// If Get is called before Initialize, an error is returned.
+func Get(name string) (*template.Template, error) {
+	if defaultCache == nil {
+		return nil, errors.New("Get was called before initializing the default cache") // TODO: wrap error at boundary
+	}
+
+	return defaultCache.Get(name)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module angusgmorrison/doppel
 
 go 1.15
+
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/option.go
+++ b/option.go
@@ -1,0 +1,25 @@
+package doppel
+
+// Option are used to decorate new Doppels, e.g. adding template
+// expiry or memory limits.
+type Option func(*Doppel) *Doppel // TODO: Ensure custom Options can't affect unexported fields.
+
+// TODO: Implement stale template expiry.
+// func WithExpiry(expireAfter time.Duration) Option {
+
+// }
+
+// TODO: Implement heartbeat.
+// func WithHeartbeat(pulseRate time.Duration) Option {
+
+// }
+
+// TODO - stretch: Implement memory limit.
+// func WithMemoryLimit(limitInMB uint64) Option {
+
+// }
+
+// TODO: Implement request timeout.
+// func WithRequestTimeout(timeout time.Duration) Option {
+
+// }


### PR DESCRIPTION
Converts code imported from FB05 to function both as a package-level cache and spawn new cache instances as required.