### PR TITLE
Enable context cancellation

### DIFF
--- a/cache_ops.go
+++ b/cache_ops.go
@@ -67,7 +67,9 @@ func (d *Doppel) parse(ce *cacheEntry, req *request) {
 			<-req.ctx.Done() // guaranteed to be closed when the parent Get returns
 			cancel()
 		}()
-		base, err := d.Get(ctx, ce.schematic.BaseTmplName)
+
+		var base *template.Template
+		base, err = d.Get(ctx, ce.schematic.BaseTmplName)
 		if err != nil {
 			ce.err = err
 			return

--- a/doppel.go
+++ b/doppel.go
@@ -32,40 +32,6 @@ type Doppel struct {
 	once          sync.Once // protects inShutdown and requestSteam from multiple closures
 }
 
-// A CacheSchematic is an acyclic graph of named TemplateSchematics
-// which reference their base templates by name.
-type CacheSchematic map[string]*TemplateSchematic
-
-// Clone returns a deep copy of the CacheSchematic.
-func (cs CacheSchematic) Clone() CacheSchematic {
-	dest := make(CacheSchematic, len(cs))
-	for k, v := range cs {
-		dest[k] = v.Clone()
-	}
-	return dest
-}
-
-// TemplateSchematic describes how to parse a template from a named
-// base template in the cache and zero or more template files.
-//
-// BaseTmplName may be an empty string, indicating a template without
-// a base.
-type TemplateSchematic struct {
-	BaseTmplName string
-	Filepaths    []string
-}
-
-// Clone returns a pointer to deep copy of the underlying
-// TemplateSchematic.
-func (ts *TemplateSchematic) Clone() *TemplateSchematic {
-	dest := &TemplateSchematic{
-		BaseTmplName: ts.BaseTmplName,
-		Filepaths:    make([]string, len(ts.Filepaths)),
-	}
-	copy(dest.Filepaths, ts.Filepaths)
-	return dest
-}
-
 type logger interface {
 	Printf(fmt string, args ...interface{})
 }

--- a/doppel.go
+++ b/doppel.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -23,27 +22,34 @@ import (
 type Doppel struct {
 	globalTimeout time.Duration
 	schematic     CacheSchematic
-	heartbeat     chan struct{} // signals the start of each work loop
-	requestStream chan *request // sends requests to the work loop
-	inShutdown    chan struct{} // signals that graceful shutdown has been triggered
-	done          chan struct{} // signals that the work loop has returned
+	heartbeat     chan struct{}   // signals the start of each work loop
+	requestStream chan<- *request // sends requests to the work loop
+	done          <-chan struct{} // signals that the cache has shut down
 	log           logger
-	retryTimeouts bool      // flags whether to retry parsing templates that have previously timed out
-	once          sync.Once // protects inShutdown and requestSteam from multiple closures
+	retryTimeouts bool // flags whether to retry parsing templates that have previously timed out
 }
 
 // New configures a new *Doppel and returns it to the caller. It
 // should not be used concurrently with operations on the provided
 // schematic.
-func New(schematic CacheSchematic, opts ...CacheOption) (*Doppel, error) {
+func New(ctx context.Context, schematic CacheSchematic, opts ...CacheOption) (*Doppel, error) {
 	if cyclic, err := IsCyclic(schematic); cyclic {
 		return nil, errors.WithStack(err)
 	}
 
+	requestStream := make(chan *request)
+	// Place the requestStream under the control of the caller as if it had
+	// created it. This way, we have knowledge about when it is safe to close
+	// the requestStream even though this function is not the sender.
+	go func() {
+		<-ctx.Done()
+		close(requestStream)
+	}()
+
 	d := &Doppel{
-		schematic:  schematic.Clone(), // prevent race conditions as a result of external access
-		inShutdown: make(chan struct{}),
-		done:       make(chan struct{}),
+		schematic:     schematic.Clone(), // prevent race conditions as a result of external access
+		done:          ctx.Done(),
+		requestStream: requestStream,
 	}
 
 	for _, opt := range opts {
@@ -54,7 +60,7 @@ func New(schematic CacheSchematic, opts ...CacheOption) (*Doppel, error) {
 		d.log = &defaultLog{}
 	}
 
-	d.startCache()
+	d.startCache(requestStream)
 	return d, nil
 }
 
@@ -74,25 +80,23 @@ type result struct {
 	err  error
 }
 
-// startCache launches a concurrent, non-blocking cache of templates
-// and sub-templates that runs until cancelled.
+// startCache launches a concurrent, non-blocking cache of templates and
+// sub-templates that runs until cancelled.
 //
-// If an error is generated when attempting to retrieve a template,
-// further requests for that template will return the original error.
+// If an error is generated when attempting to retrieve a template, further
+// requests for that template will return the original error.
 //
 // Each request to the cache is preemptible via its context.
-func (d *Doppel) startCache() {
-	// Create heartbeat and request stream synchronously to ensure
-	// a caller can never receive nil channels.
+func (d *Doppel) startCache(requestStream <-chan *request) {
+	// Create heartbeat and request stream synchronously to ensure a caller can
+	// never receive nil channels.
 	d.heartbeat = make(chan struct{}, 1)
-	d.requestStream = make(chan *request)
 
 	go func() {
 		defer close(d.heartbeat)
-		defer close(d.done)
 
 		cache := make(map[string]*cacheEntry)
-		for req := range d.requestStream {
+		for req := range requestStream {
 			d.log.Printf(logRequestReceived, req.name)
 			select {
 			case d.heartbeat <- struct{}{}:
@@ -132,7 +136,7 @@ func (d *Doppel) startCache() {
 // can be preempted via the supplied context.Context.
 func (d *Doppel) Get(ctx context.Context, name string) (*template.Template, error) {
 	select {
-	case <-d.inShutdown:
+	case <-d.done:
 		return nil, ErrDoppelShutdown
 	default:
 	}
@@ -160,6 +164,8 @@ func (d *Doppel) Get(ctx context.Context, name string) (*template.Template, erro
 	defer cancel()
 
 	select {
+	case <-d.done:
+		return nil, ErrDoppelShutdown
 	case <-ctx.Done():
 		return nil, RequestError{
 			errors.WithStack(ctx.Err()),
@@ -188,36 +194,6 @@ func (d *Doppel) Get(ctx context.Context, name string) (*template.Template, erro
 // non-nil.
 func (d *Doppel) Heartbeat() <-chan struct{} {
 	return d.heartbeat
-}
-
-// Shutdown signals to Get that it should immediately stop accepting
-// new requests. It then waits for gracePeriod to elapse before
-// closing the request stream. If any requests are still active when
-// the request stream is closed, Get will panic.
-//
-// Subseqent calls to Shutdown are no-ops.
-func (d *Doppel) Shutdown(gracePeriod time.Duration) {
-	d.once.Do(func() {
-		close(d.inShutdown) // signals that Get should no longer accept new requests
-		d.log.Printf("shutting down gracefully...")
-		go func() {
-			<-time.After(gracePeriod)
-			close(d.requestStream)
-			d.log.Printf("shutdown complete")
-		}()
-	})
-}
-
-// Close forces the Doppel to shut down without accepting pending
-// requests. When pending requests are subsequently sent to the
-// request stream, Get will panic.
-//
-// Subsequent calls to Close are no-ops.
-func (d *Doppel) Close() {
-	d.once.Do(func() {
-		close(d.inShutdown)
-		close(d.requestStream)
-	})
 }
 
 // IsCyclic reports whether a CacheSchematic contains a cycle. If

--- a/doppel.go
+++ b/doppel.go
@@ -32,18 +32,6 @@ type Doppel struct {
 	once          sync.Once // protects inShutdown and requestSteam from multiple closures
 }
 
-type logger interface {
-	Printf(fmt string, args ...interface{})
-}
-
-// defaultLog provides a no-op logger to avoid a series of nil checks throughout
-// the cache's work loop.
-type defaultLog struct{}
-
-func (d *defaultLog) Printf(format string, args ...interface{}) {
-	// No-op.
-}
-
 // New configures a new *Doppel and returns it to the caller. It
 // should not be used concurrently with operations on the provided
 // schematic.

--- a/errors.go
+++ b/errors.go
@@ -21,7 +21,7 @@ func (re RequestError) Is(err error) bool {
 
 // ErrDoppelShutdown is used in response to requests to a Doppel
 // with an closed cache.
-var ErrDoppelShutdown = errors.New("Doppel is in shutdown")
+var ErrDoppelShutdown = errors.New("can't send request to stopped cache")
 
 // ErrSchematicNotFound is used when a named TemplateSchematic isn't present
 // in the Doppel's CacheSchematic.

--- a/global_test.go
+++ b/global_test.go
@@ -3,6 +3,8 @@ package doppel
 import (
 	"context"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestInitialize(t *testing.T) {
@@ -24,7 +26,7 @@ func TestInitialize(t *testing.T) {
 		}
 		defer Close()
 		err = Initialize(schematic)
-		if err != ErrAlreadyInitialized {
+		if errors.Cause(err) != ErrAlreadyInitialized {
 			t.Errorf("got error %q, want ErrAlreadyInitialized", err)
 		}
 	})
@@ -56,7 +58,7 @@ func TestGlobalGet(t *testing.T) {
 	t.Run("returns an error if called before Initialize", func(t *testing.T) {
 		globalCache = nil
 		_, err := Get(context.Background(), "base")
-		if err != ErrNotInitialized {
+		if errors.Cause(err) != ErrNotInitialized {
 			t.Errorf("got err %q, want ErrNotInitialized", err)
 		}
 	})

--- a/global_test.go
+++ b/global_test.go
@@ -9,23 +9,29 @@ import (
 
 func TestInitialize(t *testing.T) {
 	t.Run("assigns a new *Doppel with a live cache to globalCache", func(t *testing.T) {
-		err := Initialize(schematic)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := Initialize(ctx, schematic)
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer Close()
+
 		if globalCache == nil {
 			t.Fatal("failed to assign globalCache")
 		}
 	})
 
 	t.Run("returns an error if the global cache is already initialized", func(t *testing.T) {
-		err := Initialize(schematic)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := Initialize(ctx, schematic)
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer Close()
-		err = Initialize(schematic)
+
+		err = Initialize(ctx, schematic)
 		if errors.Cause(err) != ErrAlreadyInitialized {
 			t.Errorf("got error %q, want ErrAlreadyInitialized", err)
 		}
@@ -35,11 +41,14 @@ func TestInitialize(t *testing.T) {
 func TestGlobalGet(t *testing.T) {
 	t.Run("returns the requested template", func(t *testing.T) {
 		target := "withBody1"
-		err := Initialize(schematic)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := Initialize(ctx, schematic)
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer Close()
 
 		gotTemplate, err := Get(context.Background(), target)
 		if err != nil {
@@ -62,19 +71,4 @@ func TestGlobalGet(t *testing.T) {
 			t.Errorf("got err %q, want ErrNotInitialized", err)
 		}
 	})
-}
-
-func TestGlobalShutdown(t *testing.T) {
-	err := Initialize(schematic)
-	if err != nil {
-		t.Fatal(err)
-	}
-	Shutdown(gracePeriod)
-
-	// Ensure that the underlying globalCache.Shutdown has been called, which
-	// is tested separately.
-	_, err = Get(context.Background(), "base")
-	if err != ErrDoppelShutdown {
-		t.Errorf("want ErrDoppelClosed, got %v", err)
-	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,13 @@
+package doppel
+
+type logger interface {
+	Printf(fmt string, args ...interface{})
+}
+
+// defaultLog provides a no-op logger to avoid a series of nil checks throughout
+// the cache's work loop.
+type defaultLog struct{}
+
+func (d *defaultLog) Printf(format string, args ...interface{}) {
+	// No-op.
+}

--- a/option_test.go
+++ b/option_test.go
@@ -36,12 +36,14 @@ func (tl *testLogger) String() string {
 
 func TestWithLogger(t *testing.T) {
 	t.Run("logs cache operations to the logger provded", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		l := &testLogger{out: &bytes.Buffer{}}
-		d, err := New(schematic, WithLogger(l))
+		d, err := New(ctx, schematic, WithLogger(l))
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer d.Shutdown(gracePeriod)
 		d.Get(context.Background(), "withBody1")
 
 		if gotLogs := l.String(); gotLogs == "" {
@@ -52,12 +54,14 @@ func TestWithLogger(t *testing.T) {
 
 func TestWithGlobalTimeout(t *testing.T) {
 	t.Run("Get returns context.DeadlineExceeded when timeout expires", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		globalTimeout := 1 * time.Nanosecond
-		d, err := New(schematic, WithGlobalTimeout(globalTimeout))
+		d, err := New(ctx, schematic, WithGlobalTimeout(globalTimeout))
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer d.Close()
 
 		_, err = d.Get(context.Background(), "base")
 		if !errors.Is(err, context.DeadlineExceeded) {
@@ -66,12 +70,14 @@ func TestWithGlobalTimeout(t *testing.T) {
 	})
 
 	t.Run("Get times out after the shortest of global timeout and request timeout", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		globalTimeout := 1 * time.Millisecond
-		d, err := New(schematic, WithGlobalTimeout(globalTimeout))
+		d, err := New(ctx, schematic, WithGlobalTimeout(globalTimeout))
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer d.Shutdown(gracePeriod)
 
 		reqTimeout := 1 * time.Nanosecond
 		errStream := make(chan error)

--- a/schematic.go
+++ b/schematic.go
@@ -1,0 +1,32 @@
+package doppel
+
+// A CacheSchematic is an acyclic graph of TemplateSchematics.
+type CacheSchematic map[string]*TemplateSchematic
+
+// Clone returns a deep copy of the CacheSchematic.
+func (cs CacheSchematic) Clone() CacheSchematic {
+	dest := make(CacheSchematic, len(cs))
+	for k, v := range cs {
+		dest[k] = v.Clone()
+	}
+	return dest
+}
+
+// TemplateSchematic describes how to parse a template from a cached based
+// template and zero or more template files.
+//
+// BaseTmplName may be an empty string, indicating a template without a base.
+type TemplateSchematic struct {
+	BaseTmplName string
+	Filepaths    []string
+}
+
+// Clone returns a pointer to deep copy of the underlying TemplateSchematic.
+func (ts *TemplateSchematic) Clone() *TemplateSchematic {
+	dest := &TemplateSchematic{
+		BaseTmplName: ts.BaseTmplName,
+		Filepaths:    make([]string, len(ts.Filepaths)),
+	}
+	copy(dest.Filepaths, ts.Filepaths)
+	return dest
+}


### PR DESCRIPTION
Spring cleaning, including:
* [Refactor New to take a context rather than rely on internal cancellation](https://github.com/AngusGMorrison/doppel/commit/867e0c9dc075af7dbc96940183911da2ae93e47a)
* [Unwrap errors before make assertions](https://github.com/AngusGMorrison/doppel/commit/12bbb60b2e7a1015ed8797eb09e05e43880d1053)
* [Refactor logger interface into separate file](https://github.com/AngusGMorrison/doppel/commit/06862c430205e101e0dd6118b1a8e1b7624db0fe)
* [Refactor schematic type declarations into dedicated file](https://github.com/AngusGMorrison/doppel/commit/6928631b5b26f066b8103fb5cf60033541e8a515)